### PR TITLE
Dialog cleanup

### DIFF
--- a/client/src/components/AddBoardDialog/AddBoardDialog.tsx
+++ b/client/src/components/AddBoardDialog/AddBoardDialog.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react';
-import { Button, IconButton, Box, Grid, Dialog, TextField, Typography, DialogActions } from '@material-ui/core';
+import { Button, Grid, TextField } from '@material-ui/core';
 import addBoardDialogStyles from './AddBoardDialogStyles';
 import AddOutlinedIcon from '@material-ui/icons/AddOutlined';
-import ClearIcon from '@material-ui/icons/Clear';
 import * as Yup from 'yup';
 import { Formik, useFormik } from 'formik';
 import createBoard from '../../helpers/APICalls/createBoard';
 import { IBoard } from '../../interface/Board';
 import { useSnackBar } from '../../context/useSnackbarContext';
+import StyledDialog from '../StyledDialog/StyledDialog';
 
 interface Props {
   onAddNewBoard: (board: IBoard) => void;
@@ -55,70 +55,54 @@ const AddBoardDialog = ({ onAddNewBoard }: Props): JSX.Element => {
   });
 
   return (
-    <Box>
-      <Grid item>
-        <Button
-          color="primary"
-          variant="contained"
-          size="large"
-          startIcon={<AddOutlinedIcon />}
-          onClick={handleClickOpen}
-          disableElevation
-        >
-          Create Board
-        </Button>
-      </Grid>
-      <Dialog open={open} onClose={handleClose} classes={{ paper: classes.paper }}>
-        <Typography variant="h5" className={classes.dialogTitle}>
-          Create new board
-        </Typography>
-        <Formik
-          initialValues={{ name: '' }}
-          onSubmit={(values: Values) => console.log(values.name, 'sinal')}
-          validationSchema={Yup.object().shape({
-            name: Yup.string().required(`Insert the board's name`).min(2).max(50),
-          })}
-        >
-          <form onSubmit={formik.handleSubmit}>
-            <Grid container spacing={2} className={classes.formGrid}>
-              <Grid item>
-                <TextField
-                  name="name"
-                  value={formik.values.name}
-                  onChange={formik.handleChange}
-                  error={formik.touched.name && Boolean(formik.errors.name)}
-                  helperText={formik.touched.name && formik.errors.name}
-                  fullWidth
-                  placeholder="Add Title"
-                  variant="outlined"
-                  InputProps={{
-                    classes: { input: classes.inputs },
-                  }}
-                  className={classes.textField}
-                />
+    <>
+      <Button
+        color="primary"
+        variant="contained"
+        size="large"
+        startIcon={<AddOutlinedIcon />}
+        onClick={handleClickOpen}
+        disableElevation
+      >
+        Create Board
+      </Button>
+      <StyledDialog
+        open={open}
+        buttonText="Create Board"
+        title="Create New Board"
+        toggleFunction={setOpen}
+        component={
+          <Formik
+            initialValues={{ name: '' }}
+            onSubmit={(values: Values) => console.log(values.name, 'sinal')}
+            validationSchema={Yup.object().shape({
+              name: Yup.string().required(`Insert the board's name`).min(2).max(50),
+            })}
+          >
+            <form onSubmit={formik.handleSubmit}>
+              <Grid container spacing={2} className={classes.formGrid}>
+                <Grid item>
+                  <TextField
+                    name="name"
+                    value={formik.values.name}
+                    onChange={formik.handleChange}
+                    error={formik.touched.name && Boolean(formik.errors.name)}
+                    helperText={formik.touched.name && formik.errors.name}
+                    fullWidth
+                    placeholder="Add Title"
+                    variant="outlined"
+                    InputProps={{
+                      classes: { input: classes.inputs },
+                    }}
+                    className={classes.textField}
+                  />
+                </Grid>
               </Grid>
-              <Grid item>
-                <Button
-                  type="submit"
-                  className={classes.dialogButton}
-                  color="primary"
-                  variant="contained"
-                  size="large"
-                  disableElevation
-                >
-                  Create
-                </Button>
-              </Grid>
-            </Grid>
-          </form>
-        </Formik>
-        <DialogActions>
-          <IconButton className={classes.topRight} onClick={handleClose}>
-            <ClearIcon />
-          </IconButton>
-        </DialogActions>
-      </Dialog>
-    </Box>
+            </form>
+          </Formik>
+        }
+      />
+    </>
   );
 };
 

--- a/client/src/components/AddColumnDialog/AddColumnDialog.tsx
+++ b/client/src/components/AddColumnDialog/AddColumnDialog.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react';
-import { Button, IconButton, Box, Grid, Dialog, TextField, Typography, DialogActions } from '@material-ui/core';
+import { Button, TextField, Grid, Box } from '@material-ui/core';
 import addColumnDialogStyles from './AddColumnDialogStyles';
 import AddCircleOutlineOutlinedIcon from '@material-ui/icons/AddCircleOutlineOutlined';
-import ClearIcon from '@material-ui/icons/Clear';
 import StyledDialog from '../StyledDialog/StyledDialog';
 
 const AddColumnDialog = (): JSX.Element => {
@@ -11,10 +10,6 @@ const AddColumnDialog = (): JSX.Element => {
 
   const handleClickOpen = () => {
     setOpen(true);
-  };
-
-  const handleClose = () => {
-    setOpen(false);
   };
 
   return (

--- a/client/src/components/AddColumnDialog/AddColumnDialog.tsx
+++ b/client/src/components/AddColumnDialog/AddColumnDialog.tsx
@@ -3,6 +3,7 @@ import { Button, IconButton, Box, Grid, Dialog, TextField, Typography, DialogAct
 import addColumnDialogStyles from './AddColumnDialogStyles';
 import AddCircleOutlineOutlinedIcon from '@material-ui/icons/AddCircleOutlineOutlined';
 import ClearIcon from '@material-ui/icons/Clear';
+import StyledDialog from '../StyledDialog/StyledDialog';
 
 const AddColumnDialog = (): JSX.Element => {
   const [open, setOpen] = useState(false);
@@ -30,36 +31,24 @@ const AddColumnDialog = (): JSX.Element => {
           </Button>
         </Grid>
       </Grid>
-      <Dialog open={open} onClose={handleClose} classes={{ paper: classes.paper }}>
-        <Typography variant="h5" className={classes.dialogTitle}>
-          Create a new column
-        </Typography>
-        <TextField
-          required
-          fullWidth
-          placeholder="Add Title"
-          variant="outlined"
-          InputProps={{
-            classes: { input: classes.inputs },
-          }}
-          className={classes.textField}
-        />
-        <DialogActions>
-          <IconButton className={classes.topRight} onClick={handleClose}>
-            <ClearIcon />
-          </IconButton>
-          <Button
-            onClick={handleClose}
-            className={classes.dialogButton}
-            color="primary"
-            variant="contained"
-            size="large"
-            disableElevation
-          >
-            Create
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <StyledDialog
+        open={open}
+        buttonText="Create"
+        title="Create a new column"
+        toggleFunction={setOpen}
+        component={
+          <TextField
+            required
+            fullWidth
+            placeholder="Add Title"
+            variant="outlined"
+            InputProps={{
+              classes: { input: classes.inputs },
+            }}
+            className={classes.textField}
+          />
+        }
+      />
     </Box>
   );
 };

--- a/client/src/components/AddColumnDialog/AddColumnDialogStyles.ts
+++ b/client/src/components/AddColumnDialog/AddColumnDialogStyles.ts
@@ -8,24 +8,10 @@ const addColumnDialogStyles = makeStyles((theme) => ({
   textField: {
     display: 'flex',
     textAlign: 'center',
-    width: '80%',
-  },
-  paper: {
-    minWidth: '30%',
-    minHeight: '40%',
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    padding: '20px 10px',
-  },
-  dialogTitle: {
-    fontWeight: 'bold',
-    paddingTop: '40px',
   },
   inputs: {
     height: '3rem',
-    padding: '5px',
+    padding: '5px 60px',
     background: 'white',
     textAlign: 'center',
     borderRadius: '5px',

--- a/client/src/components/Kanban/Board.tsx
+++ b/client/src/components/Kanban/Board.tsx
@@ -5,32 +5,34 @@ import { FocusCard } from './FocusCard/FocusCard';
 import Column from './Column/Column';
 
 const Board = (): JSX.Element => {
-  const { columns, handleDragEnd } = useKanban();
+  const { focusedCard, columns, handleDragEnd } = useKanban();
   return (
-    <DragDropContext onDragEnd={handleDragEnd}>
-      <Droppable droppableId="board" type="column" direction="horizontal">
-        {(provided: DroppableProvided) => {
-          return (
-            <Grid ref={provided.innerRef} container spacing={2} {...provided.droppableProps}>
-              {columns.map((column, index) => (
-                <>
-                  <FocusCard />
-                  <Column
-                    key={column.id}
-                    index={index}
-                    id={column.id}
-                    name={column.name}
-                    cards={column.cards}
-                    createdAt={column.createdAt}
-                  />
-                </>
-              ))}
-              {provided.placeholder}
-            </Grid>
-          );
-        }}
-      </Droppable>
-    </DragDropContext>
+    <>
+      {focusedCard && <FocusCard />}
+      <DragDropContext onDragEnd={handleDragEnd}>
+        <Droppable droppableId="board" type="column" direction="horizontal">
+          {(provided: DroppableProvided) => {
+            return (
+              <Grid ref={provided.innerRef} container spacing={2} {...provided.droppableProps}>
+                {columns.map((column, index) => (
+                  <>
+                    <Column
+                      key={column.id}
+                      index={index}
+                      id={column.id}
+                      name={column.name}
+                      cards={column.cards}
+                      createdAt={column.createdAt}
+                    />
+                  </>
+                ))}
+                {provided.placeholder}
+              </Grid>
+            );
+          }}
+        </Droppable>
+      </DragDropContext>
+    </>
   );
 };
 

--- a/client/src/components/StyledDialog/StyledDialog.tsx
+++ b/client/src/components/StyledDialog/StyledDialog.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Button, IconButton, Dialog, Typography, DialogActions } from '@material-ui/core';
+import ClearIcon from '@material-ui/icons/Clear';
+import styledDialogStyles from './styledDialogStyles';
+
+type Props = {
+  open: boolean;
+  buttonText: string;
+  title: string;
+  toggleFunction: React.Dispatch<React.SetStateAction<boolean>>;
+  component: JSX.Element;
+};
+
+const StyledDialog = ({ open, buttonText, title, toggleFunction, component }: Props): JSX.Element => {
+  const classes = styledDialogStyles();
+
+  const handleClose = () => {
+    toggleFunction(false);
+  };
+
+  return (
+    <>
+      <Dialog maxWidth="sm" open={open} onClose={handleClose} classes={{ paper: classes.paper }}>
+        <Typography variant="h5" className={classes.dialogTitle}>
+          {title}
+        </Typography>
+        {component}
+        <Button
+          type="submit"
+          className={classes.dialogButton}
+          color="primary"
+          variant="contained"
+          size="large"
+          disableElevation
+        >
+          {buttonText}
+        </Button>
+        <DialogActions>
+          <IconButton className={classes.topRight} onClick={handleClose}>
+            <ClearIcon />
+          </IconButton>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default StyledDialog;

--- a/client/src/components/StyledDialog/styledDialogStyles.ts
+++ b/client/src/components/StyledDialog/styledDialogStyles.ts
@@ -1,6 +1,6 @@
 import { makeStyles } from '@material-ui/core/styles';
 
-const addBoardDialogStyles = makeStyles(() => ({
+const styledDialogStyles = makeStyles(() => ({
   textField: {
     display: 'flex',
     textAlign: 'center',
@@ -38,4 +38,4 @@ const addBoardDialogStyles = makeStyles(() => ({
   },
 }));
 
-export default addBoardDialogStyles;
+export default styledDialogStyles;


### PR DESCRIPTION
### What this PR does (required):
- Creates reusable `StyledDialog` higher-order component to unify dialog features within application.
- Allows passing a valid React component as a prop to create a customized dialog for various purposes
- Adapts `AddBoardDialog` and `AddColumnDialog` to use this generic component (+appropriate props) where they previously used `Dialog`.

### Screenshots / Videos (required):
![image](https://user-images.githubusercontent.com/67977894/120410313-9b24ce00-c307-11eb-9ab5-9bae1808cd8b.png)
![image](https://user-images.githubusercontent.com/67977894/120411375-8d704800-c309-11eb-9369-9f9c9390ae97.png)

### Any information needed to test this feature (required):
- Open either dialog via current methods
### Any issues with the current functionality (optional):
- May have conflicts with whatever is happening with AddColumnDialog but should be pretty easy to re-integrate
