### PR TITLE
Refactoring interfaces to remain consistent and one source of truth

### DIFF
--- a/client/src/components/NavBar/Notifications/NotificationCenter/NotificationCenter.tsx
+++ b/client/src/components/NavBar/Notifications/NotificationCenter/NotificationCenter.tsx
@@ -3,8 +3,7 @@ import { Popover, IconButton } from '@material-ui/core';
 import NotificationsIcon from '@material-ui/icons/Notifications';
 import NotificationItem from '../NotificationItem/NotificationItem';
 import { StyledBadge } from './notificationCenterStyles';
-import INotificationItem from '../../../../interface/Notification';
-import { IUser } from '../../../../interface/';
+import { IUser, INotificationItem } from '../../../../interface/';
 
 type NotificationProps = {
   loggedInUser: IUser;

--- a/client/src/components/NavBar/Notifications/NotificationItem/NotificationItem.tsx
+++ b/client/src/components/NavBar/Notifications/NotificationItem/NotificationItem.tsx
@@ -5,8 +5,8 @@ import ClearIcon from '@material-ui/icons/Clear';
 import AssignmentOutlinedIcon from '@material-ui/icons/AssignmentOutlined';
 import CheckBoxOutlinedIcon from '@material-ui/icons/CheckBoxOutlined';
 import ScheduleIcon from '@material-ui/icons/Schedule';
-import INotificationItem from '../../../../interface/Notification';
 import { testNotifications } from '../sampleNotificationData';
+import { INotificationItem } from '../../../../interface/';
 
 type NotificationItemProps = INotificationItem;
 

--- a/client/src/components/NavBar/Notifications/sampleNotificationData.ts
+++ b/client/src/components/NavBar/Notifications/sampleNotificationData.ts
@@ -1,4 +1,4 @@
-import INotificationItem from '../../../interface/Notification';
+import { INotificationItem } from '../../../interface/';
 
 export const testNotifications: INotificationItem[] = [
   {

--- a/client/src/interface/AuthApiData.ts
+++ b/client/src/interface/AuthApiData.ts
@@ -1,4 +1,4 @@
-import { IUser } from './User';
+import { IUser } from './';
 
 export interface IAuthApiDataSuccess {
   message: string;

--- a/client/src/interface/Board.ts
+++ b/client/src/interface/Board.ts
@@ -1,5 +1,4 @@
-import { IColumn } from './Column';
-import { ICard } from './Card';
+import { IColumn, ICard } from './';
 
 export interface IBoard {
   _id: string;

--- a/client/src/interface/Card.ts
+++ b/client/src/interface/Card.ts
@@ -1,4 +1,4 @@
-export interface ICard {
+export default interface ICard {
   _id: string;
   columnId: string;
   name: string;

--- a/client/src/interface/Column.ts
+++ b/client/src/interface/Column.ts
@@ -1,6 +1,6 @@
-import { ICard } from './Card';
+import { ICard } from './';
 
-export interface IColumn {
+export default interface IColumn {
   _id: string;
   name: string;
   cards: Array<ICard>;

--- a/client/src/interface/DialogItemContext.ts
+++ b/client/src/interface/DialogItemContext.ts
@@ -1,6 +1,6 @@
-import { IDialogItem } from './DialogItem';
+import { IDialogItem } from './';
 
-export interface IDialogItemContext {
+export default interface IDialogItemContext {
   items: IDialogItem[];
   addItem: (item: IDialogItem) => void;
   removeItem: (itemId: string) => void;

--- a/client/src/interface/FetchOptions.ts
+++ b/client/src/interface/FetchOptions.ts
@@ -1,4 +1,4 @@
-export interface IFetchOptions {
+export default interface IFetchOptions {
   method: string;
   headers?: {
     'Content-Type': string;

--- a/client/src/interface/KanbanContext.ts
+++ b/client/src/interface/KanbanContext.ts
@@ -1,7 +1,7 @@
 import { DropResult } from 'react-beautiful-dnd';
 import { IBoard, NewBoardApiData, ICard, IColumn } from './';
 
-export interface IKanbanContext {
+export default interface IKanbanContext {
   activeBoard: IBoard;
   focusedCard: ICard | null;
   userBoards: IBoard[];

--- a/client/src/interface/index.ts
+++ b/client/src/interface/index.ts
@@ -1,10 +1,11 @@
 export type { IUser, ISearchUsersApiData } from './User';
 export type { IBoard, NewBoardApiData, BoardApiData } from './Board';
-export type { ICard } from './Card';
-export type { IColumn } from './Column';
+export type { default as ICard } from './Card';
+export type { default as IColumn } from './Column';
 export type { IDialogItem } from './DialogItem';
-export type { IFetchOptions } from './FetchOptions';
+export type { default as IFetchOptions } from './FetchOptions';
 export type { IImageUploadData, IUploadOptions } from './File';
 export type { IAuthApiDataSuccess, IAuthApiData } from './AuthApiData';
-export type { IKanbanContext } from './KanbanContext';
-export type { IDialogItemContext } from './DialogItemContext';
+export type { default as IKanbanContext } from './KanbanContext';
+export type { default as IDialogItemContext } from './DialogItemContext';
+export type { default as INotificationItem } from './Notification';


### PR DESCRIPTION
### What this PR does (required):
- Refactoring interface imports to use our index file as a single source of truth rather than importing from individual interface files.

### Screenshots / Videos (required):
- No action here; it's in the small changes of code.

### Any information needed to test this feature (required):
- Issues could arise where an interface could be changed from `default` to non-default, breaking the interface and all its usage. 
- Could test by breaking the code but that'd be redundant