### PR TITLE
added toggle function to card dialog items via side buttons

### DIFF
--- a/client/src/components/CardDialog/DialogActionButton/DialogActionButton.tsx
+++ b/client/src/components/CardDialog/DialogActionButton/DialogActionButton.tsx
@@ -10,20 +10,21 @@ type Props = {
 };
 
 const DialogActionButton = ({ title, content, icon }: Props): JSX.Element => {
-  const { hasItem, addItem } = useDialog();
+  const { hasItem, addItem, removeItem } = useDialog();
   const classes = dialogActionButtonStyles();
 
   return (
     <Button
       className={hasItem(content) ? classes.columnButtonActive : classes.columnButton}
-      disabled={hasItem(content)}
       onClick={() => {
-        addItem({
-          title: `${title}:`,
-          content: content,
-          icon: icon,
-          id: uuidv4(),
-        });
+        if (!hasItem(content)) {
+          addItem({
+            title: `${title}:`,
+            content: content,
+            icon: icon,
+            id: uuidv4(),
+          });
+        } else removeItem(content);
       }}
     >
       {title}

--- a/client/src/context/useDialogContext.tsx
+++ b/client/src/context/useDialogContext.tsx
@@ -18,8 +18,8 @@ export const DialogProvider: FunctionComponent = ({ children }): JSX.Element => 
     setItems(itemsPlusOne);
   };
 
-  const removeItem = (itemId: string): void => {
-    const remaining = items.filter((item) => item.id !== itemId);
+  const removeItem = (itemContent: string): void => {
+    const remaining = items.filter((item) => item.content !== itemContent);
     setItems(remaining);
   };
 


### PR DESCRIPTION
### What this PR does (required):
- Card dialog section buttons now correctly toggle which sections are enabled. 

### Screenshots / Videos (required):
![image](https://user-images.githubusercontent.com/67977894/121727316-9945d200-caa0-11eb-88d9-6be09f494b57.png)


### Any information needed to test this feature (required):
- Play with dialog buttons

### Any issues with the current functionality (optional):
- Dialog section state is not linked to backend currently so changes will not persist
